### PR TITLE
Controller Mouse get lost, when active window is closed in Windows 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ More instruction in the configuration file.
 
 ```diff
 + If you make a config file you feel could benefit people with the same use scenario as you, feel free to make a pull request for it in the public configs directory.
-+ comment
++ comment2
 ```
 
 


### PR DESCRIPTION
In Windows 11, when closing an active window, the mouse gets stuck. Then, it can only be moved by the physical mouse, not by controller (gopher). It works again with the controller, after a left-click with the physical mouse is performed. Can you fix it?